### PR TITLE
Improve fetch/transform workflow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -22,7 +22,7 @@ jobs:
           pipenv install
       - name: Fetch
         run: |
-          curl https://ukrepeater.net/csvcreate4.php > packetlist.csv
+          make --always-make packetlist.csv
       - name: Transform
         run: |
           make packetlist.json

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -25,7 +25,7 @@ jobs:
           curl https://ukrepeater.net/csvcreate4.php > packetlist.csv
       - name: Transform
         run: |
-          pipenv run python transform.py packetlist.csv packetlist.json
+          make packetlist.json
       - name: Commit and push if changed
         run: |
           git config user.name "Automation"

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -16,13 +16,15 @@ jobs:
         uses: actions/checkout@v3
       - name: Python
         uses: actions/setup-python@v4
+      - name: Python setup
+        run: |
+          pip install pipenv
+          pipenv install
       - name: Fetch
         run: |
           curl https://ukrepeater.net/csvcreate4.php > packetlist.csv
       - name: Transform
         run: |
-          pip install pipenv
-          pipenv install
           pipenv run python transform.py packetlist.csv packetlist.json
       - name: Commit and push if changed
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
+packetlist.csv:
+	curl https://ukrepeater.net/csvcreate4.php > packetlist.csv
+
 packetlist.json: packetlist.csv transform.py Makefile
 	pipenv run python3 transform.py packetlist.csv packetlist.json

--- a/transform.py
+++ b/transform.py
@@ -21,7 +21,14 @@ def transform(infile, outfile):
 
             print(f"Processing {callsign} at {maidenhead}")
 
-            lat, lon = mh.to_location(maidenhead, center=True)
+            try:
+                lat, lon = mh.to_location(maidenhead, center=True)
+            except ValueError as e:
+                # Sometimes the ETCC publish invalid Maidenhead locators
+                # e.g. 2023-11-01 MB7TF was reported at J0O2AL
+                # So let's handle *somewhat* gracefully...
+                print(f"Error parsing {callsign}'s Maidenhead locator ({maidenhead}): {e}")
+                lat, lon = 0, 0
 
             feature = {
                 "type": "Feature",


### PR DESCRIPTION
- Split out Python setup from the transformation step
- Use Makefile in GitHub Action
- Add `make packetlist.csv` for easier testing
- Handle Maidenhead parse failures more gracefully
